### PR TITLE
Expose generic execute method in DefaultApiClient

### DIFF
--- a/pca-client/src/main/java/com/sdl/web/pca/client/DefaultApiClient.java
+++ b/pca-client/src/main/java/com/sdl/web/pca/client/DefaultApiClient.java
@@ -56,7 +56,7 @@ import static com.sdl.web.pca.client.modelserviceplugin.ClaimHelper.createClaim;
 import static com.sdl.web.pca.client.modelserviceplugin.ClaimHelper.createClaimTcdlBinaryLinkUrlPrefix;
 import static com.sdl.web.pca.client.modelserviceplugin.ClaimHelper.createClaimTcdlLinkUrlPrefix;
 
-public class DefaultApiClient implements ApiClient {
+public class DefaultApiClient implements ApiClient, GraphQLClient {
     private static final Logger LOG = LoggerFactory.getLogger(DefaultApiClient.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -166,6 +166,21 @@ public class DefaultApiClient implements ApiClient {
     @Override
     public void addDefaultHeader(String header, String value) {
         this.client.addDefaultHeader(header, value);
+    }
+
+    @Override
+    public String execute(String jsonEntity, int timeout) throws UnauthorizedException, GraphQLClientException {
+        return client.execute(jsonEntity, timeout);
+    }
+
+    @Override
+    public String execute(String jsonEntity) throws UnauthorizedException, GraphQLClientException {
+        return client.execute(jsonEntity);
+    }
+
+    @Override
+    public String execute(GraphQLRequest request) throws UnauthorizedException, GraphQLClientException {
+        return client.execute(request);
     }
 
     @Override

--- a/pca-integration-tests/pom.xml
+++ b/pca-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pca-client-parent</artifactId>
         <groupId>com.sdl.web.pca</groupId>
-        <version>2.2.14-SNAPSHOT</version>
+        <version>2.2.19-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Added GraphQLClient interface to DefaultApiClient to allow consumers to execute adhoc GraphQL queries. This capability was already in the .NET version.